### PR TITLE
Updates made by ansible with play: persist

### DIFF
--- a/host_vars/ansible-2.yaml
+++ b/host_vars/ansible-2.yaml
@@ -1,0 +1,428 @@
+- address_family:
+  - afi: ipv4
+    networks:
+    - prefix: 10.0.0.0/24
+    - prefix: 172.16.0.0/16
+    safi: unicast
+  - afi: ipv6
+    networks:
+    - prefix: 2001:db8::/32
+    - prefix: 2001:db8:abcd::/48
+    safi: unicast
+  as_number: '65001'
+- as_number: '65001'
+  neighbors:
+  - neighbor_address: 192.168.1.2
+    remote_as: '65002'
+    update_source: loopback0
+  - neighbor_address: 192.168.2.1
+    remote_as: '65002'
+  - neighbor_address: 2001:db8::2
+    remote_as: '65003'
+  router_id: 1.1.1.1
+  timers:
+    bgp:
+      holdtime: 90
+      keepalive: 30
+- - name: Vlan1
+  - name: Vlan10
+  - description: UPLINK-LAG
+    name: port-channel1
+  - name: port-channel10
+  - name: port-channel111
+  - duplex: full
+    name: Ethernet1/1
+    speed: '1000'
+  - name: Ethernet1/2
+  - mode: layer3
+    name: Ethernet1/3
+  - name: Ethernet1/4
+  - name: Ethernet1/5
+  - name: Ethernet1/6
+  - name: Ethernet1/7
+  - name: Ethernet1/8
+  - name: Ethernet1/9
+  - name: Ethernet1/10
+  - name: Ethernet1/11
+  - name: Ethernet1/12
+  - name: Ethernet1/13
+  - name: Ethernet1/14
+  - name: Ethernet1/15
+  - name: Ethernet1/16
+  - name: Ethernet1/17
+  - name: Ethernet1/18
+  - name: Ethernet1/19
+  - name: Ethernet1/20
+  - name: Ethernet1/21
+  - name: Ethernet1/22
+  - name: Ethernet1/23
+  - name: Ethernet1/24
+  - name: Ethernet1/25
+  - name: Ethernet1/26
+  - name: Ethernet1/27
+  - name: Ethernet1/28
+  - name: Ethernet1/29
+  - enabled: true
+    mode: layer3
+    name: Ethernet1/30
+  - name: Ethernet1/31
+  - name: Ethernet1/32
+  - enabled: true
+    mode: layer3
+    name: Ethernet1/33
+  - name: Ethernet1/34
+  - name: Ethernet1/35
+  - name: Ethernet1/36
+  - name: Ethernet1/37
+  - name: Ethernet1/38
+  - name: Ethernet1/39
+  - name: Ethernet1/40
+  - name: Ethernet1/41
+  - name: Ethernet1/42
+  - name: Ethernet1/43
+  - name: Ethernet1/44
+  - name: Ethernet1/45
+  - name: Ethernet1/46
+  - name: Ethernet1/47
+  - name: Ethernet1/48
+  - name: Ethernet1/49
+  - name: Ethernet1/50
+  - name: Ethernet1/51
+  - name: Ethernet1/52
+  - name: Ethernet1/53
+  - name: Ethernet1/54
+  - name: Ethernet1/55
+  - name: Ethernet1/56
+  - name: Ethernet1/57
+  - name: Ethernet1/58
+  - name: Ethernet1/59
+  - name: Ethernet1/60
+  - name: Ethernet1/61
+  - description: Configured via network.base
+    name: Ethernet1/62
+  - name: Ethernet1/63
+  - name: Ethernet1/64
+  - name: mgmt0
+- - name: Vlan1
+  - name: Vlan10
+  - mode: trunk
+    name: port-channel1
+    trunk:
+      allowed_vlans: 10,20,30
+  - name: port-channel10
+  - mode: trunk
+    name: port-channel111
+  - name: Ethernet1/1
+  - name: Ethernet1/2
+  - name: Ethernet1/3
+  - name: Ethernet1/4
+  - name: Ethernet1/5
+  - name: Ethernet1/6
+  - name: Ethernet1/7
+  - name: Ethernet1/8
+  - name: Ethernet1/9
+  - name: Ethernet1/10
+  - name: Ethernet1/11
+  - name: Ethernet1/12
+  - name: Ethernet1/13
+  - name: Ethernet1/14
+  - name: Ethernet1/15
+  - name: Ethernet1/16
+  - name: Ethernet1/17
+  - name: Ethernet1/18
+  - name: Ethernet1/19
+  - name: Ethernet1/20
+  - name: Ethernet1/21
+  - name: Ethernet1/22
+  - name: Ethernet1/23
+  - name: Ethernet1/24
+  - name: Ethernet1/25
+  - name: Ethernet1/26
+  - name: Ethernet1/27
+  - name: Ethernet1/28
+  - name: Ethernet1/29
+  - name: Ethernet1/30
+  - name: Ethernet1/31
+  - name: Ethernet1/32
+  - name: Ethernet1/33
+  - name: Ethernet1/34
+  - name: Ethernet1/35
+  - name: Ethernet1/36
+  - name: Ethernet1/37
+  - name: Ethernet1/38
+  - name: Ethernet1/39
+  - name: Ethernet1/40
+  - name: Ethernet1/41
+  - name: Ethernet1/42
+  - name: Ethernet1/43
+  - name: Ethernet1/44
+  - name: Ethernet1/45
+  - name: Ethernet1/46
+  - name: Ethernet1/47
+  - name: Ethernet1/48
+  - name: Ethernet1/49
+  - name: Ethernet1/50
+  - name: Ethernet1/51
+  - name: Ethernet1/52
+  - name: Ethernet1/53
+  - name: Ethernet1/54
+  - name: Ethernet1/55
+  - name: Ethernet1/56
+  - name: Ethernet1/57
+  - name: Ethernet1/58
+  - name: Ethernet1/59
+  - name: Ethernet1/60
+  - name: Ethernet1/61
+  - name: Ethernet1/62
+  - name: Ethernet1/63
+  - name: Ethernet1/64
+  - name: mgmt0
+- - name: Vlan1
+  - ipv4:
+    - address: 192.168.10.1/24
+    ipv6:
+    - address: 2001:db8:10::1/64
+    name: Vlan10
+  - name: port-channel1
+  - name: port-channel10
+  - name: port-channel111
+  - name: Ethernet1/1
+  - name: Ethernet1/2
+  - name: Ethernet1/3
+  - name: Ethernet1/4
+  - name: Ethernet1/5
+  - name: Ethernet1/6
+  - name: Ethernet1/7
+  - name: Ethernet1/8
+  - name: Ethernet1/9
+  - name: Ethernet1/10
+  - name: Ethernet1/11
+  - name: Ethernet1/12
+  - name: Ethernet1/13
+  - name: Ethernet1/14
+  - name: Ethernet1/15
+  - name: Ethernet1/16
+  - name: Ethernet1/17
+  - name: Ethernet1/18
+  - name: Ethernet1/19
+  - name: Ethernet1/20
+  - name: Ethernet1/21
+  - name: Ethernet1/22
+  - name: Ethernet1/23
+  - name: Ethernet1/24
+  - name: Ethernet1/25
+  - name: Ethernet1/26
+  - name: Ethernet1/27
+  - name: Ethernet1/28
+  - name: Ethernet1/29
+  - ipv4:
+    - address: 192.168.1.10/30
+    name: Ethernet1/30
+  - name: Ethernet1/31
+  - name: Ethernet1/32
+  - ipv4:
+    - address: dhcp
+    name: Ethernet1/33
+  - name: Ethernet1/34
+  - name: Ethernet1/35
+  - name: Ethernet1/36
+  - name: Ethernet1/37
+  - name: Ethernet1/38
+  - name: Ethernet1/39
+  - name: Ethernet1/40
+  - name: Ethernet1/41
+  - name: Ethernet1/42
+  - name: Ethernet1/43
+  - name: Ethernet1/44
+  - name: Ethernet1/45
+  - name: Ethernet1/46
+  - name: Ethernet1/47
+  - name: Ethernet1/48
+  - name: Ethernet1/49
+  - name: Ethernet1/50
+  - name: Ethernet1/51
+  - name: Ethernet1/52
+  - name: Ethernet1/53
+  - name: Ethernet1/54
+  - name: Ethernet1/55
+  - name: Ethernet1/56
+  - name: Ethernet1/57
+  - name: Ethernet1/58
+  - name: Ethernet1/59
+  - name: Ethernet1/60
+  - name: Ethernet1/61
+  - name: Ethernet1/62
+  - name: Ethernet1/63
+  - name: Ethernet1/64
+  - ipv4:
+    - address: dhcp
+    name: mgmt0
+- processes:
+  - process_id: '100'
+    router_id: 203.0.113.20
+  - areas:
+    - area_id: 0.0.0.100
+      filter_list:
+      - direction: out
+        route_map: rmap_2
+      - direction: in
+        route_map: rmap_1
+      ranges:
+      - not_advertise: true
+        prefix: 198.51.100.64/27
+      - cost: 120
+        prefix: 198.51.100.96/27
+    - area_id: 0.0.0.101
+      authentication:
+        message_digest: true
+    process_id: '102'
+    redistribute:
+    - protocol: direct
+      route_map: ospf102-direct-connect
+    - id: '120'
+      protocol: eigrp
+      route_map: rmap_1
+    router_id: 198.51.100.1
+    vrfs:
+    - areas:
+      - area_id: 0.0.0.102
+        nssa:
+          default_information_originate: true
+          no_summary: true
+      - area_id: 0.0.0.103
+        nssa:
+          no_summary: true
+          translate:
+            type7:
+              always: true
+      redistribute:
+      - protocol: static
+        route_map: zone1-static-connect
+      router_id: 198.51.100.129
+      summary_address:
+      - prefix: 198.51.100.128/27
+        tag: 121
+      - prefix: 198.51.100.160/27
+      vrf: zone1
+    - auto_cost:
+        reference_bandwidth: 45
+        unit: Gbps
+      vrf: zone2
+- processes:
+  - process_id: '100'
+    router_id: 203.0.113.20
+  - address_family:
+      afi: ipv6
+      areas:
+      - area_id: 0.0.0.100
+        filter_list:
+        - direction: out
+          route_map: rmap_2
+        - direction: in
+          route_map: rmap_1
+        ranges:
+        - not_advertise: true
+          prefix: 2001:db2::/32
+        - cost: 120
+          prefix: 2001:db3::/32
+      redistribute:
+      - protocol: direct
+        route_map: ospf102-direct-connect
+      - id: '120'
+        protocol: eigrp
+        route_map: rmap_1
+      safi: unicast
+    process_id: '102'
+    router_id: 198.51.100.1
+    vrfs:
+    - areas:
+      - area_id: 0.0.0.102
+        nssa:
+          default_information_originate: true
+          no_summary: true
+      - area_id: 0.0.0.103
+        nssa:
+          no_summary: true
+          translate:
+            type7:
+              always: true
+      router_id: 198.51.100.129
+      vrf: zone1
+    - auto_cost:
+        reference_bandwidth: 45
+        unit: Gbps
+      vrf: zone2
+  - address_family:
+      afi: ipv6
+      areas:
+      - area_id: 0.0.0.100
+        filter_list:
+        - direction: out
+          route_map: rmap_2
+        - direction: in
+          route_map: rmap_1
+        ranges:
+        - not_advertise: true
+          prefix: 2001:db2::/32
+        - cost: 120
+          prefix: 2001:db3::/32
+      redistribute:
+      - protocol: direct
+        route_map: ospf102-direct-connect
+      - id: '120'
+        protocol: eigrp
+        route_map: rmap_1
+      safi: unicast
+    process_id: '201'
+    router_id: 192.0.2.1
+    vrfs:
+    - areas:
+      - area_id: 0.0.0.102
+        nssa:
+          default_information_originate: true
+          no_summary: true
+      - area_id: 0.0.0.103
+        nssa:
+          no_summary: true
+          translate:
+            type7:
+              always: true
+      auto_cost:
+        reference_bandwidth: 45
+        unit: Gbps
+      router_id: 198.51.100.129
+      vrf: zone1
+- bootflash: 4495360
+  device_name: aayushNXOS
+  hardware:
+    model: Nexus9000 C9300v
+    serial_number: 9GT0HF5KR3M
+  last_reset_reason: Unknown
+  license:
+    count: 1
+    description: LAN license for Nexus 9300-XF
+    enforcement_type: NOT ENFORCED
+    license_type: Generic
+    name: LAN_ENTERPRISE_SERVICES_PKG
+    status: IN USE
+    version: 1.0
+  memory:
+    free_mb: 1470.2578125
+    total_mb: 7945.015625
+    used_mb: 6474.7578125
+  nxos_compile_time: 11/30/2023 12:00:00 [12/14/2023 05:25:50]
+  nxos_image_file: bootflash:///nxos64-cs.10.4.2.F.bin
+  os_type: NX-OS
+  processes:
+    running: 1
+    total: 903
+  processor:
+    memory: 8135696
+    type: Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz
+  release_type: Feature Release
+  uptime:
+    days: 111
+    hours: 12
+    minutes: 3
+    seconds: 0
+  version: 10.4(2)

--- a/host_vars/ansible-3.yaml
+++ b/host_vars/ansible-3.yaml
@@ -1,0 +1,196 @@
+- address_family:
+  - afi: ipv4
+    neighbor:
+    - activate: true
+      peer: 1.1.1.1
+    network:
+    - address: 1.1.1.0/24
+    - address: 1.5.1.0/24
+      route_map: MAP01
+    redistribute:
+    - ospf_route: external
+      protocol: ospfv3
+  as_number: '100'
+- aggregate_address:
+  - address: 1.2.1.0/24
+    as_set: true
+    match_map: match01
+  - address: 5.2.1.0/24
+    advertise_only: true
+    attribute_map: attrmatch01
+  as_number: '100'
+  bgp_params:
+    additional_paths: send
+    convergence:
+      slow_peer: true
+      time: 6
+  distance:
+    external: 50
+    internal: 50
+    local: 50
+  maximum_paths:
+    max_equal_cost_paths: 55
+  neighbor:
+  - link_bandwidth:
+      set: true
+      update_delay: 5
+    maximum_received_routes:
+      count: 12000
+    monitoring: true
+    neighbor_address: peer1
+    peer_group: peer1
+    send_community:
+      community_attribute: extended
+      link_bandwidth_attribute: aggregate
+      speed: '600'
+      sub_attribute: link-bandwidth
+  - maximum_received_routes:
+      count: 12000
+    neighbor_address: peer2
+    peer_group: peer2
+  - maximum_received_routes:
+      count: 12000
+    neighbor_address: 1.1.1.1
+  - allowas_in:
+      count: 3
+    default_originate:
+      always: true
+    dont_capability_negotiate: true
+    export_localpref: 4000
+    maximum_received_routes:
+      count: 500
+      warning_limit:
+        limit_percent: 5
+    neighbor_address: 10.1.3.2
+    next_hop_unchanged: true
+  redistribute:
+  - protocol: static
+    route_map: map_static
+  - protocol: attached-host
+- - enabled: true
+    name: Ethernet1
+  - enabled: true
+    name: Ethernet2
+  - enabled: true
+    name: Ethernet3
+  - enabled: true
+    name: Ethernet4
+  - enabled: true
+    name: Ethernet5
+  - enabled: true
+    name: Ethernet6
+  - enabled: true
+    name: Ethernet7
+  - enabled: true
+    name: Ethernet8
+  - enabled: true
+    name: Ethernet9
+  - enabled: true
+    name: Ethernet10
+  - enabled: true
+    name: Ethernet11
+  - enabled: true
+    name: Ethernet12
+  - enabled: true
+    name: Loopback0
+  - description: Management Interface
+    enabled: true
+    name: Management1
+  - enabled: true
+    name: Vlan1
+- - name: Ethernet1
+  - name: Ethernet2
+  - name: Ethernet3
+  - name: Ethernet4
+  - name: Ethernet5
+  - name: Ethernet6
+  - name: Ethernet7
+  - name: Ethernet8
+  - name: Ethernet9
+  - name: Ethernet10
+  - name: Ethernet11
+  - name: Ethernet12
+  - name: Loopback0
+  - name: Management1
+  - name: Vlan1
+- - name: Ethernet1
+  - name: Ethernet2
+  - name: Ethernet3
+  - name: Ethernet4
+  - name: Ethernet5
+  - name: Ethernet6
+  - name: Ethernet7
+  - name: Ethernet8
+  - name: Ethernet9
+  - name: Ethernet10
+  - name: Ethernet11
+  - name: Ethernet12
+  - ipv4:
+    - address: 2.2.2.2/32
+    name: Loopback0
+  - ipv4:
+    - address: dhcp
+    name: Management1
+  - name: Vlan1
+- processes:
+  - adjacency:
+      exchange_start:
+        threshold: 20045623
+    areas:
+    - area_id: 0.0.0.2
+      filter:
+        address: 10.1.1.0/24
+    - area_id: 0.0.0.50
+      range:
+        address: 172.20.0.0/16
+        cost: 34
+    default_information:
+      metric: 100
+      metric_type: 1
+      originate: true
+    distance:
+      intra_area: 85
+    max_lsa:
+      count: 8000
+      ignore_count: 3
+      ignore_time: 6
+      reset_time: 20
+      threshold: 40
+    networks:
+    - area: 0.0.0.0
+      prefix: 10.10.2.0/24
+    - area: 0.0.0.0
+      prefix: 10.10.3.0/24
+    process_id: 1
+    redistribute:
+    - routes: static
+    router_id: 170.21.0.4
+- processes:
+  - address_family:
+    - afi: ipv6
+      fips_restrictions: true
+      graceful_restart:
+        grace_period: 35
+    fips_restrictions: true
+    router_id: 2.2.2.2
+    timers:
+      pacing: 55
+    vrf: vrfmerge
+- build_info:
+    internal_build_id: 2f026fab-f3ea-4171-9e76-42c5c3dedf3e
+    internal_build_version: 4.24.6M-22486697.4246M
+  device_name: eos-switch
+  hardware:
+    mac_address: 5254.00d9.190b
+  memory:
+    free_mb: 1269.54296875
+    total_mb: 1967.21484375
+  system:
+    architecture: i686
+    mac_address: 5254.00d9.190b
+  uptime:
+    days: 0
+    hours: 21
+    minutes: 27
+    weeks: 0
+  version: 4.24.6M


### PR DESCRIPTION
## Summary by Sourcery

Add host variable configuration files for two network devices with detailed network settings including BGP, OSPF, interface configurations, and system information

New Features:
- Create comprehensive host variable configuration for two network devices (ansible-2 and ansible-3)

Enhancements:
- Define detailed network configurations including address families, routing protocols, and interface settings
- Specify BGP and OSPF process configurations with advanced routing parameters

Chores:
- Add system and hardware information for network devices
- Define interface and VLAN configurations