### PR TITLE
Updates made by ansible with play: persist

### DIFF
--- a/host_vars/ansible-2.yaml
+++ b/host_vars/ansible-2.yaml
@@ -1,0 +1,413 @@
+- bgp_address_family:
+    address_family:
+    - afi: ipv4
+      networks:
+      - prefix: 10.0.0.0/24
+      - prefix: 172.16.0.0/16
+      safi: unicast
+    - afi: ipv6
+      networks:
+      - prefix: 2001:db8::/32
+      - prefix: 2001:db8:abcd::/48
+      safi: unicast
+    as_number: '65001'
+- bgp_global:
+    as_number: '65001'
+    neighbors:
+    - neighbor_address: 192.168.1.2
+      remote_as: '65002'
+      update_source: loopback0
+    - neighbor_address: 192.168.2.1
+      remote_as: '65002'
+    - neighbor_address: 2001:db8::2
+      remote_as: '65003'
+    router_id: 1.1.1.1
+    timers:
+      bgp:
+        holdtime: 90
+        keepalive: 30
+- interfaces:
+  - name: Vlan1
+  - name: Vlan10
+  - description: UPLINK-LAG
+    name: port-channel1
+  - name: port-channel10
+  - name: port-channel111
+  - duplex: full
+    name: Ethernet1/1
+    speed: '1000'
+  - name: Ethernet1/2
+  - mode: layer3
+    name: Ethernet1/3
+  - name: Ethernet1/4
+  - name: Ethernet1/5
+  - name: Ethernet1/6
+  - name: Ethernet1/7
+  - name: Ethernet1/8
+  - name: Ethernet1/9
+  - name: Ethernet1/10
+  - name: Ethernet1/11
+  - name: Ethernet1/12
+  - name: Ethernet1/13
+  - name: Ethernet1/14
+  - name: Ethernet1/15
+  - name: Ethernet1/16
+  - name: Ethernet1/17
+  - name: Ethernet1/18
+  - name: Ethernet1/19
+  - name: Ethernet1/20
+  - name: Ethernet1/21
+  - name: Ethernet1/22
+  - name: Ethernet1/23
+  - name: Ethernet1/24
+  - name: Ethernet1/25
+  - name: Ethernet1/26
+  - name: Ethernet1/27
+  - name: Ethernet1/28
+  - name: Ethernet1/29
+  - enabled: true
+    mode: layer3
+    name: Ethernet1/30
+  - description: Link to Network A
+    name: Ethernet1/31
+  - name: Ethernet1/32
+  - enabled: true
+    mode: layer3
+    name: Ethernet1/33
+  - name: Ethernet1/34
+  - name: Ethernet1/35
+  - name: Ethernet1/36
+  - name: Ethernet1/37
+  - name: Ethernet1/38
+  - name: Ethernet1/39
+  - name: Ethernet1/40
+  - name: Ethernet1/41
+  - name: Ethernet1/42
+  - name: Ethernet1/43
+  - name: Ethernet1/44
+  - name: Ethernet1/45
+  - name: Ethernet1/46
+  - name: Ethernet1/47
+  - name: Ethernet1/48
+  - name: Ethernet1/49
+  - name: Ethernet1/50
+  - name: Ethernet1/51
+  - name: Ethernet1/52
+  - name: Ethernet1/53
+  - name: Ethernet1/54
+  - name: Ethernet1/55
+  - name: Ethernet1/56
+  - name: Ethernet1/57
+  - name: Ethernet1/58
+  - name: Ethernet1/59
+  - name: Ethernet1/60
+  - name: Ethernet1/61
+  - description: Configured via network.base
+    name: Ethernet1/62
+  - name: Ethernet1/63
+  - name: Ethernet1/64
+  - name: mgmt0
+- l2_interfaces:
+  - name: Vlan1
+  - name: Vlan10
+  - mode: trunk
+    name: port-channel1
+    trunk:
+      allowed_vlans: 10,20,30
+  - name: port-channel10
+  - mode: trunk
+    name: port-channel111
+  - name: Ethernet1/1
+  - name: Ethernet1/2
+  - name: Ethernet1/3
+  - name: Ethernet1/4
+  - name: Ethernet1/5
+  - name: Ethernet1/6
+  - name: Ethernet1/7
+  - name: Ethernet1/8
+  - name: Ethernet1/9
+  - name: Ethernet1/10
+  - name: Ethernet1/11
+  - name: Ethernet1/12
+  - name: Ethernet1/13
+  - name: Ethernet1/14
+  - name: Ethernet1/15
+  - name: Ethernet1/16
+  - name: Ethernet1/17
+  - name: Ethernet1/18
+  - name: Ethernet1/19
+  - name: Ethernet1/20
+  - name: Ethernet1/21
+  - name: Ethernet1/22
+  - name: Ethernet1/23
+  - name: Ethernet1/24
+  - name: Ethernet1/25
+  - name: Ethernet1/26
+  - name: Ethernet1/27
+  - name: Ethernet1/28
+  - name: Ethernet1/29
+  - name: Ethernet1/30
+  - name: Ethernet1/31
+  - name: Ethernet1/32
+  - name: Ethernet1/33
+  - name: Ethernet1/34
+  - name: Ethernet1/35
+  - name: Ethernet1/36
+  - name: Ethernet1/37
+  - name: Ethernet1/38
+  - name: Ethernet1/39
+  - name: Ethernet1/40
+  - name: Ethernet1/41
+  - name: Ethernet1/42
+  - name: Ethernet1/43
+  - name: Ethernet1/44
+  - name: Ethernet1/45
+  - name: Ethernet1/46
+  - name: Ethernet1/47
+  - name: Ethernet1/48
+  - name: Ethernet1/49
+  - name: Ethernet1/50
+  - name: Ethernet1/51
+  - name: Ethernet1/52
+  - name: Ethernet1/53
+  - name: Ethernet1/54
+  - name: Ethernet1/55
+  - name: Ethernet1/56
+  - name: Ethernet1/57
+  - name: Ethernet1/58
+  - name: Ethernet1/59
+  - name: Ethernet1/60
+  - name: Ethernet1/61
+  - name: Ethernet1/62
+  - name: Ethernet1/63
+  - name: Ethernet1/64
+  - name: mgmt0
+- l3_interfaces:
+  - name: Vlan1
+  - ipv4:
+    - address: 192.168.10.1/24
+    ipv6:
+    - address: 2001:db8:10::1/64
+    name: Vlan10
+  - name: port-channel1
+  - name: port-channel10
+  - name: port-channel111
+  - name: Ethernet1/1
+  - name: Ethernet1/2
+  - name: Ethernet1/3
+  - name: Ethernet1/4
+  - name: Ethernet1/5
+  - name: Ethernet1/6
+  - name: Ethernet1/7
+  - name: Ethernet1/8
+  - name: Ethernet1/9
+  - name: Ethernet1/10
+  - name: Ethernet1/11
+  - name: Ethernet1/12
+  - name: Ethernet1/13
+  - name: Ethernet1/14
+  - name: Ethernet1/15
+  - name: Ethernet1/16
+  - name: Ethernet1/17
+  - name: Ethernet1/18
+  - name: Ethernet1/19
+  - name: Ethernet1/20
+  - name: Ethernet1/21
+  - name: Ethernet1/22
+  - name: Ethernet1/23
+  - name: Ethernet1/24
+  - name: Ethernet1/25
+  - name: Ethernet1/26
+  - name: Ethernet1/27
+  - name: Ethernet1/28
+  - name: Ethernet1/29
+  - ipv4:
+    - address: 192.168.1.10/30
+    name: Ethernet1/30
+  - name: Ethernet1/31
+  - name: Ethernet1/32
+  - ipv4:
+    - address: dhcp
+    name: Ethernet1/33
+  - name: Ethernet1/34
+  - name: Ethernet1/35
+  - name: Ethernet1/36
+  - name: Ethernet1/37
+  - name: Ethernet1/38
+  - name: Ethernet1/39
+  - name: Ethernet1/40
+  - name: Ethernet1/41
+  - name: Ethernet1/42
+  - name: Ethernet1/43
+  - name: Ethernet1/44
+  - name: Ethernet1/45
+  - name: Ethernet1/46
+  - name: Ethernet1/47
+  - name: Ethernet1/48
+  - name: Ethernet1/49
+  - name: Ethernet1/50
+  - name: Ethernet1/51
+  - name: Ethernet1/52
+  - name: Ethernet1/53
+  - name: Ethernet1/54
+  - name: Ethernet1/55
+  - name: Ethernet1/56
+  - name: Ethernet1/57
+  - name: Ethernet1/58
+  - name: Ethernet1/59
+  - name: Ethernet1/60
+  - name: Ethernet1/61
+  - name: Ethernet1/62
+  - name: Ethernet1/63
+  - name: Ethernet1/64
+  - ipv4:
+    - address: dhcp
+    name: mgmt0
+- ospfv2:
+    processes:
+    - process_id: '100'
+      router_id: 203.0.113.20
+    - areas:
+      - area_id: 0.0.0.100
+        filter_list:
+        - direction: out
+          route_map: rmap_2
+        - direction: in
+          route_map: rmap_1
+        ranges:
+        - not_advertise: true
+          prefix: 198.51.100.64/27
+        - cost: 120
+          prefix: 198.51.100.96/27
+      - area_id: 0.0.0.101
+        authentication:
+          message_digest: true
+      process_id: '102'
+      redistribute:
+      - protocol: direct
+        route_map: ospf102-direct-connect
+      - id: '120'
+        protocol: eigrp
+        route_map: rmap_1
+      router_id: 198.51.100.1
+      vrfs:
+      - areas:
+        - area_id: 0.0.0.102
+          nssa:
+            default_information_originate: true
+            no_summary: true
+        - area_id: 0.0.0.103
+          nssa:
+            no_summary: true
+            translate:
+              type7:
+                always: true
+        redistribute:
+        - protocol: static
+          route_map: zone1-static-connect
+        router_id: 198.51.100.129
+        summary_address:
+        - prefix: 198.51.100.128/27
+          tag: 121
+        - prefix: 198.51.100.160/27
+        vrf: zone1
+      - auto_cost:
+          reference_bandwidth: 45
+          unit: Gbps
+        vrf: zone2
+- ospfv3:
+    processes:
+    - process_id: '100'
+      router_id: 203.0.113.20
+    - address_family:
+        afi: ipv6
+        areas:
+        - area_id: 0.0.0.100
+          filter_list:
+          - direction: out
+            route_map: rmap_2
+          - direction: in
+            route_map: rmap_1
+          ranges:
+          - not_advertise: true
+            prefix: 2001:db2::/32
+          - cost: 120
+            prefix: 2001:db3::/32
+        redistribute:
+        - protocol: direct
+          route_map: ospf102-direct-connect
+        - id: '120'
+          protocol: eigrp
+          route_map: rmap_1
+        safi: unicast
+      process_id: '102'
+      router_id: 198.51.100.1
+      vrfs:
+      - areas:
+        - area_id: 0.0.0.102
+          nssa:
+            default_information_originate: true
+            no_summary: true
+        - area_id: 0.0.0.103
+          nssa:
+            no_summary: true
+            translate:
+              type7:
+                always: true
+        router_id: 198.51.100.129
+        vrf: zone1
+      - auto_cost:
+          reference_bandwidth: 45
+          unit: Gbps
+        vrf: zone2
+    - address_family:
+        afi: ipv6
+        areas:
+        - area_id: 0.0.0.100
+          filter_list:
+          - direction: out
+            route_map: rmap_2
+          - direction: in
+            route_map: rmap_1
+          ranges:
+          - not_advertise: true
+            prefix: 2001:db2::/32
+          - cost: 120
+            prefix: 2001:db3::/32
+        redistribute:
+        - protocol: direct
+          route_map: ospf102-direct-connect
+        - id: '120'
+          protocol: eigrp
+          route_map: rmap_1
+        safi: unicast
+      process_id: '201'
+      router_id: 192.0.2.1
+      vrfs:
+      - areas:
+        - area_id: 0.0.0.102
+          nssa:
+            default_information_originate: true
+            no_summary: true
+        - area_id: 0.0.0.103
+          nssa:
+            no_summary: true
+            translate:
+              type7:
+                always: true
+        auto_cost:
+          reference_bandwidth: 45
+          unit: Gbps
+        router_id: 198.51.100.129
+        vrf: zone1
+- device_info: "- bootflash: 4495360\n  device_name: aayushNXOS\n  hardware:\n    model:
+    Nexus9000 C9300v\n    serial_number: 9GT0HF5KR3M\n  last_reset_reason: Unknown\n
+    \ license:\n    count: 1\n    description: LAN license for Nexus 9300-XF\n    enforcement_type:
+    NOT ENFORCED\n    license_type: Generic\n    name: LAN_ENTERPRISE_SERVICES_PKG\n
+    \   status: IN USE\n    version: 1.0\n  memory:\n    free_mb: 1539.05078125\n
+    \   total_mb: 7945.015625\n    used_mb: 6405.96484375\n  nxos_compile_time: 11/30/2023
+    12:00:00 [12/14/2023 05:25:50]\n  nxos_image_file: bootflash:///nxos64-cs.10.4.2.F.bin\n
+    \ os_type: NX-OS\n  processes:\n    running: 1\n    total: 894\n  processor:\n
+    \   memory: 8135696\n    type: Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz\n
+    \ release_type: Feature Release\n  uptime:\n    days: 112\n    hours: 21\n    minutes:
+    50\n    seconds: 6\n  version: 10.4(2)\n"

--- a/host_vars/ansible-4.yaml
+++ b/host_vars/ansible-4.yaml
@@ -1,0 +1,103 @@
+- bgp_address_family:
+    address_family:
+    - advertise_best_external: true
+      afi: ipv4
+      allocate_label:
+        all: true
+      bgp:
+        attribute_download: true
+        scan_time: 20
+      safi: unicast
+    - afi: vpnv4
+      safi: unicast
+    - afi: ipv4
+      dynamic_med: 9
+      redistribute:
+      - metric: 10
+        protocol: connected
+      safi: unicast
+      vrf: vrf1
+    as_number: '65001'
+- bgp_global:
+    as_number: '65001'
+    bgp:
+      router_id: 192.0.1.1
+    neighbors:
+    - neighbor_address: 192.0.2.1
+      remote_as: 65002
+    timers:
+      holdtime: 90
+      keepalive_time: 30
+    vrfs:
+    - rd:
+        auto: true
+      vrf: vrf1
+- interfaces:
+  - enabled: true
+    name: Loopback0
+  - enabled: true
+    name: MgmtEth0/RP0/CPU0/0
+  - enabled: true
+    name: GigabitEthernet0/0/0/0
+  - enabled: true
+    name: GigabitEthernet0/0/0/1
+- l2_interfaces:
+  - name: Loopback0
+  - name: MgmtEth0/RP0/CPU0/0
+  - name: GigabitEthernet0/0/0/0
+  - name: GigabitEthernet0/0/0/1
+- l3_interfaces:
+  - name: Loopback0
+  - ipv4:
+    - address: dhcp
+    name: MgmtEth0/RP0/CPU0/0
+  - ipv4:
+    - address: 10.1.1.1/29
+    name: GigabitEthernet0/0/0/0
+  - ipv4:
+    - address: 10.0.0.1/24
+    name: GigabitEthernet0/0/0/1
+- ospfv2:
+    processes:
+    - process_id: LAB3
+      router_id: 1.1.1.1
+    - process_id: MYOSPF
+- ospfv3:
+    processes:
+    - areas:
+      - area_id: '11'
+        cost: 11
+        default_cost: 5
+      - area_id: '22'
+        default_cost: 6
+      process_id: '10'
+    - authentication:
+        disable: true
+      process_id: '26'
+    - areas:
+      - area_id: '10'
+        hello_interval: 2
+      process_id: '27'
+- build_info:
+    built_by: ingunawa
+    built_host: iox-ucs-067
+    built_on: Mon Jul 25 02:41:45 PDT 2022
+    label: 7.7.1-0
+    location: /opt/cisco/XR/packages/
+    workspace: /auto/srcarchive12/prod/7.7.1/xrv9k/ws
+  device_name: iosxr
+  hardware:
+    model: cisco IOS-XRv 9000
+  license:
+    count: 1
+    export_status: NOT RESTRICTED
+    name: IOS-XRv-9000-vRouter-VM
+    status: EVAL MODE
+    version: 1.0
+  memory:
+    free_mb: 3566M
+    total_mb: 6144M
+  memory_summary:
+    image_size: 4M
+  os_type: IOS XR
+  version: 7.7.1


### PR DESCRIPTION
## Summary by Sourcery

Add host variable configuration files for two network devices with detailed network settings including BGP, interfaces, OSPF, and device information

New Features:
- Create comprehensive host variable configurations for two different network devices (ansible-2 and ansible-4)

Enhancements:
- Define detailed BGP address family configurations
- Configure multiple network interfaces with IP addressing
- Set up OSPF processes with various parameters

Chores:
- Add device information and build details for network devices